### PR TITLE
chore: update gitignore for VS2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+.vs/
+/Buses.sln.DotSettings.user


### PR DESCRIPTION
Updating the gitignore file for VS2022 files.